### PR TITLE
fix: updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 ```bash
 # copy env and adjust its content
+# you can get an access token from https://thegraph.com/explorer/dashboard
 cp .env.test .env
+# install project dependencies
+npm i
 # fetch current contracts as submodule
 npm run prepare:all
 # run codegen

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "This package contains subgraph of the protocol v2",
   "scripts": {
-    "dev-environment": "npm i && tail -f /dev/null",
     "update-address": "node ./scripts/updateMigratorAddress",
     "update-abi-addresses": "npm run update-address && npm run prepare:abi",
     "prepare:all": "npm run prepare:contracts && npm run prepare:subgraph",

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1,6 +1,6 @@
 specVersion: 0.0.2
 description: Protocol v2 subgraph
-repository: https://gitlab.com/aave-tech/dlp/token-migration-subgraph.git
+repository: https://github.com/aave/protocol-v2-subgraph
 schema:
   file: ./schema.graphql
 dataSources:


### PR DESCRIPTION
Updated documentation to include install step, and fixed old links to gitlab repo.

This closes:
https://github.com/aave/protocol-v2-subgraph/issues/3
https://github.com/aave/protocol-v2-subgraph/issues/4
https://github.com/aave/protocol-v2-subgraph/issues/5