### PR TITLE
fix: persist averageStableRate in history

### DIFF
--- a/src/mapping/tokenization.ts
+++ b/src/mapping/tokenization.ts
@@ -116,6 +116,7 @@ function saveReserve(reserve: Reserve, event: ethereum.Event): void {
   reserveParamsHistoryItem.liquidityIndex = reserve.liquidityIndex;
   reserveParamsHistoryItem.liquidityRate = reserve.liquidityRate;
   reserveParamsHistoryItem.totalATokenSupply = reserve.totalATokenSupply;
+  reserveParamsHistoryItem.averageStableBorrowRate = reserve.averageStableRate;
   let priceOracleAsset = getPriceOracleAsset(reserve.price);
   reserveParamsHistoryItem.priceInEth = priceOracleAsset.priceInEth;
 


### PR DESCRIPTION
it was already there, but always 0 as it's never updated after initialization